### PR TITLE
[axs15231] lvgl support

### DIFF
--- a/components/axs15231/display/axs15231_display.h
+++ b/components/axs15231/display/axs15231_display.h
@@ -17,9 +17,7 @@ class AXS15231Display : public display::DisplayBuffer,
   void update() override;
 
   float get_setup_priority() const override;
-
   void setup() override;
-
   bool can_proceed() override;
 
   void dump_config() override;
@@ -38,57 +36,43 @@ class AXS15231Display : public display::DisplayBuffer,
   uint32_t get_buffer_length_();
 
   void set_reset_pin(GPIOPin *reset_pin);
-
   void set_backlight_pin(GPIOPin *backlight_pin);
-
   void set_width(uint16_t width);
-
   void set_dimensions(uint16_t width, uint16_t height);
-
   void set_mirror_x(bool mirror_x);
-
   void set_mirror_y(bool mirror_y);
-
   void set_swap_xy(bool swap_xy);
-
   void set_brightness(uint8_t brightness);
-
   void set_offsets(int16_t offset_x, int16_t offset_y);
 
  protected:
   void setup_pins_();
-
-  void set_madctl_();
+  void setup_madctl_();
 
   void init_lcd_();
 
   void reset_();
-
-  void display_();
-
   void invalidate_();
 
   void write_command_(uint8_t cmd, const uint8_t *bytes, size_t len);
-
   void write_command_(uint8_t cmd, uint8_t data);
-
   void write_command_(uint8_t cmd);
-
   void set_addr_window_(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2);
 
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
-
+  void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
+                      display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;
+  void write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
+                         int x_pad);
  private:
   GPIOPin *reset_pin_{nullptr};
   GPIOPin *backlight_pin_{nullptr};
-  uint16_t x_low_{0};
-  uint16_t y_low_{0};
+
+  uint16_t x_low_{1};
+  uint16_t y_low_{1};
   uint16_t x_high_{0};
   uint16_t y_high_{0};
   bool setup_complete_{};
-
-  bool prossing_update_ = false;
-  bool need_update_ = false;
 
   size_t width_{};
   size_t height_{};
@@ -97,6 +81,7 @@ class AXS15231Display : public display::DisplayBuffer,
   bool swap_xy_{};
   bool mirror_x_{};
   bool mirror_y_{};
+  bool draw_from_origin_{true};
   uint8_t brightness_{0xD0};
 };
 

--- a/examples/axs15231/t-display-s3-long-landscape.yaml
+++ b/examples/axs15231/t-display-s3-long-landscape.yaml
@@ -22,6 +22,8 @@ external_components:
   - source: github://buglloc/esphome-components
     components: [axs15231, sy6970]
 
+logger:
+
 spi:
   id: lily_spi
   type: quad
@@ -62,6 +64,7 @@ display:
     reset_pin: 16
     backlight_pin: 1
     rotation: 270
+    auto_clear_enabled: false
     lambda: |-
       it.fill(id(bg_color));
       it.print(20, 20, id(font_std), Color(255, 0, 0), TextAlign::LEFT, "@UTBDK");
@@ -91,7 +94,7 @@ touchscreen:
           do { newColor =  Color::random_color(); } while (newColor == id(point_color) || newColor == id(bg_color));
           id(point_color) = newColor;
 
-          ESP_LOGI("touch", "x=%d, y=%d, x_raw=%d, y_raw=%0d",
+          ESP_LOGI("touch", "x=%d, y=%d, x_raw=%d, y_raw=%d",
             touch.x,
             touch.y,
             touch.x_raw,

--- a/examples/axs15231/t-display-s3-long-lvgl.yaml
+++ b/examples/axs15231/t-display-s3-long-lvgl.yaml
@@ -1,0 +1,130 @@
+esphome:
+  name: t-display-s3-long
+  friendly_name: LilyGo-T-Display-Long
+  platformio_options:
+    upload_speed: 921600
+    build_unflags: -Werror=all
+    board_build.flash_mode: dio
+    board_build.f_flash: 80000000L
+    board_build.f_cpu: 240000000L
+
+psram:
+  mode: octal
+  speed: 120MHz
+
+esp32:
+  board: esp32-s3-devkitc-1
+  flash_size: 16MB
+  framework:
+    type: esp-idf
+
+external_components:
+  - source: github://buglloc/esphome-components
+    components: [axs15231, sy6970]
+
+logger:
+
+spi:
+  id: lily_spi
+  type: quad
+  clk_pin: 17
+  data_pins:
+    - 13
+    - 18
+    - 21
+    - 14
+
+i2c:
+  sda: 15
+  scl: 10
+  id: lily_i2c
+
+display:
+  - platform: axs15231
+    id: lily_display
+    spi_id: lily_spi
+    dimensions:
+      height: 640
+      width: 180
+    cs_pin: 12
+    reset_pin: 16
+    backlight_pin: 1
+    update_interval: never
+    auto_clear_enabled: false
+    rotation: 270
+
+sy6970:
+  i2c_id: lily_i2c
+  state_led_enable: false
+
+sensor:
+  - platform: template
+    name: "random temp"
+    id: random_temp
+    unit_of_measurement: "°C"
+    lambda: |-
+      return rand() % 40;
+    update_interval: 200ms
+    on_value:
+      - lvgl.indicator.update:
+          id: temperature_needle
+          value: !lambda return x * 10;
+      - lvgl.label.update:
+          id: temperature_text
+          text:
+            format: "%.1f°C"
+            args: [ 'x' ]
+
+lvgl:
+  displays:
+    - lily_display
+
+  pages:
+    - id: meter_page
+      widgets:
+        - meter:
+            align: CENTER
+            height: 180
+            width: 180
+            scales:
+              - range_from: -100 # scale for the needle value
+                range_to: 400
+                angle_range: 240
+                rotation: 150
+                indicators:
+                  - line:
+                      id: temperature_needle
+                      width: 2
+                      color: 0xFF0000
+                      r_mod: -4
+                  - tick_style:
+                      start_value: -10
+                      end_value: 40
+                      color_start: 0x0000bd
+                      color_end: 0xbd0000
+                      width: 1
+              - range_from: -10 # scale for the value labels
+                range_to: 40
+                angle_range: 240
+                rotation: 150
+                ticks:
+                  width: 1
+                  count: 51
+                  length: 10
+                  color: 0x000000
+                  major:
+                    stride: 5
+                    width: 2
+                    length: 10
+                    color: 0x404040
+                    label_gap: 10
+            widgets:
+              - label:
+                  id: temperature_text
+                  text: "-.-°C"
+                  align: CENTER
+                  y: 45
+              - label:
+                  text: "Outdoor"
+                  align: CENTER
+                  y: 65

--- a/examples/axs15231/t-display-s3-long-portrait.yaml
+++ b/examples/axs15231/t-display-s3-long-portrait.yaml
@@ -22,6 +22,8 @@ external_components:
   - source: github://buglloc/esphome-components
     components: [axs15231, sy6970]
 
+logger:
+
 spi:
   id: lily_spi
   type: quad
@@ -62,6 +64,7 @@ display:
     reset_pin: 16
     backlight_pin: 1
     rotation: 0
+    auto_clear_enabled: false
     lambda: |-
       it.fill(id(bg_color));
       it.print(20, 20, id(font_std), Color(255, 0, 0), TextAlign::LEFT, "@UTBDK");
@@ -91,7 +94,7 @@ touchscreen:
           do { newColor =  Color::random_color(); } while (newColor == id(point_color) || newColor == id(bg_color));
           id(point_color) = newColor;
 
-          ESP_LOGI("touch", "x=%d, y=%d, x_raw=%d, y_raw=%0d",
+          ESP_LOGI("touch", "x=%d, y=%d, x_raw=%d, y_raw=%d",
             touch.x,
             touch.y,
             touch.x_raw,


### PR DESCRIPTION
Fixes #12 and so on.

A few notes:
  - display implementation based on the [qspi_dbi](https://github.com/esphome/esphome/tree/dev/esphome/components/qspi_dbi) component from the ESPHome dev branch, so I plan to remove my own when the "qspi_dbi" release is available :)
  - there are problems with touchscreen coordinates when display rotation is used. Haven't debugged it yet, will try later

Demo:
  - config: https://github.com/buglloc/esphome-components/blob/axs15231_lvgl/examples/axs15231/t-display-s3-long-lvgl.yaml
  - demo: https://youtu.be/kdzd-ney4_A